### PR TITLE
Add blast count

### DIFF
--- a/src/main/java/io/icker/obsidian/Config.java
+++ b/src/main/java/io/icker/obsidian/Config.java
@@ -17,7 +17,7 @@ import net.fabricmc.loader.api.FabricLoader;
 public class Config {
     private static final File file = FabricLoader.getInstance().getGameDir().resolve("config").resolve("obsidian.json").toFile();
 
-    public static HashMap<String, Float> load() {
+    public static HashMap<String, HashMap<String, Float>> load() {
         Gson gson = new GsonBuilder().disableHtmlEscaping().create();
 
         if (!file.exists()) {
@@ -26,7 +26,7 @@ public class Config {
         }
 
         try {
-            Type type = new TypeToken<HashMap<String, Float>>(){}.getType();
+            Type type = new TypeToken<HashMap<String, HashMap<String, Float>>>(){}.getType();
             return gson.fromJson(new FileReader(file), type);
         } catch (JsonSyntaxException | JsonIOException | FileNotFoundException e) {
             Obsidian.LOGGER.warn("Could not read Obsidian config file. All blocks will have their default blast resistance");

--- a/src/main/java/io/icker/obsidian/Obsidian.java
+++ b/src/main/java/io/icker/obsidian/Obsidian.java
@@ -1,18 +1,66 @@
 package io.icker.obsidian;
 
-import net.fabricmc.api.ModInitializer;
-
+import java.io.File;
+import java.io.IOException;
 import java.util.HashMap;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import net.fabricmc.api.ModInitializer;
+import net.fabricmc.loader.api.FabricLoader;
+import net.minecraft.nbt.NbtCompound;
+import net.minecraft.nbt.NbtIo;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.world.World;
+
 public class Obsidian implements ModInitializer {
     public static final Logger LOGGER = LoggerFactory.getLogger("Obsidian");
-    public static final HashMap<String, Float> CONFIG = Config.load();
+    public static final HashMap<String, HashMap<String, Float>> CONFIG = Config.load();
+    private static NbtCompound database = new NbtCompound();
+    private static File file;
 
     @Override
     public void onInitialize() {
         LOGGER.info("Obsidian mod initialized");
+
+        file = FabricLoader.getInstance().getGameDir().resolve("config").resolve("obsidian.dat").toFile();
+        if (!file.exists()) {
+            try {
+                NbtIo.writeCompressed(new NbtCompound(), file);
+            } catch (IOException e) {
+                LOGGER.error("Failed to create NBT file", e);
+            }
+        }
+
+        try {
+            database = NbtIo.readCompressed(file);
+        } catch (IOException e) {
+            LOGGER.error("Failed to load NBT file", e);
+        }
+    }
+
+    private static String getKey(World world, BlockPos pos, String key) {
+        return String.format("%s-%d-%d-%d-%s", world.getRegistryKey().getValue().toString(), pos.getX(), pos.getY(), pos.getZ(), key);
+    }
+
+    public static void setBlastCount(World world, BlockPos pos, String key, int count) {
+        database.putInt(getKey(world, pos, key), count);
+    }
+
+    public static int getBlastCount(World world, BlockPos pos, String key) {
+        return database.getInt(getKey(world, pos, key));
+    }
+    
+    public static void removeBlastCount(World world, BlockPos pos, String key) {
+        database.remove(getKey(world, pos, key));
+    }
+
+    public static void save() {
+        try {
+            NbtIo.writeCompressed(database, file);
+        } catch (IOException e) {
+            LOGGER.error("Failed to save NBT file", e);
+        }
     }
 }

--- a/src/main/java/io/icker/obsidian/mixin/BlockMixin.java
+++ b/src/main/java/io/icker/obsidian/mixin/BlockMixin.java
@@ -18,7 +18,7 @@ public class BlockMixin {
         String key = Registry.BLOCK.getId((Block) (Object) this).toString();
 
         if (Obsidian.CONFIG.containsKey(key)) {
-            info.setReturnValue(Obsidian.CONFIG.get(key));
+            info.setReturnValue(Obsidian.CONFIG.get(key).get("resistance"));
         }
     }
 }

--- a/src/main/java/io/icker/obsidian/mixin/ExplosionMixin.java
+++ b/src/main/java/io/icker/obsidian/mixin/ExplosionMixin.java
@@ -1,0 +1,45 @@
+package io.icker.obsidian.mixin;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+import io.icker.obsidian.Obsidian;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.util.registry.Registry;
+import net.minecraft.world.World;
+import net.minecraft.world.explosion.Explosion;
+
+
+@Mixin(Explosion.class)
+public class ExplosionMixin {
+    @Shadow
+    public List<BlockPos> affectedBlocks;
+
+    @Shadow
+    public World world;
+
+    @Inject(method = "collectBlocksAndDamageEntities", at = @At("TAIL"))
+    private void collectBlocksAndDamageEntities(CallbackInfo info) {
+        ArrayList<BlockPos> blocksToRemove = new ArrayList<BlockPos>();
+        this.affectedBlocks.forEach(blockPos -> {
+            String key = Registry.BLOCK.getId(this.world.getBlockState(blockPos).getBlock()).toString();
+
+            if (Obsidian.CONFIG.containsKey(key)) {
+                int blastCount = Obsidian.getBlastCount(this.world, blockPos, key);
+                if (blastCount < Obsidian.CONFIG.get(key).get("count")) {
+                    blocksToRemove.add(blockPos);
+                    Obsidian.setBlastCount(this.world, blockPos, key, blastCount + 1);
+                } else {
+                    Obsidian.removeBlastCount(world, blockPos, key);
+                }
+            }
+        });
+        blocksToRemove.forEach(this.affectedBlocks::remove);
+    }
+}

--- a/src/main/java/io/icker/obsidian/mixin/MinecraftServerMixin.java
+++ b/src/main/java/io/icker/obsidian/mixin/MinecraftServerMixin.java
@@ -1,0 +1,17 @@
+package io.icker.obsidian.mixin;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+import io.icker.obsidian.Obsidian;
+import net.minecraft.server.MinecraftServer;
+
+@Mixin(MinecraftServer.class)
+public class MinecraftServerMixin {
+    @Inject(at = @At("HEAD"), method="Lnet/minecraft/server/MinecraftServer;save(ZZZ)Z")
+    public void save(boolean suppressLogs, boolean flush, boolean force, CallbackInfoReturnable<Boolean> ci) {
+        Obsidian.save();
+    }
+}

--- a/src/main/resources/obsidian.mixins.json
+++ b/src/main/resources/obsidian.mixins.json
@@ -4,7 +4,9 @@
   "package": "io.icker.obsidian.mixin",
   "compatibilityLevel": "JAVA_17",
   "mixins": [
-    "BlockMixin"
+    "BlockMixin",
+    "ExplosionMixin",
+    "MinecraftServerMixin"
   ],
   "injectors": {
     "defaultRequire": 1


### PR DESCRIPTION
Adds a 'blast count', this allows the user to specify how many times a block can be exploded before it actually breaks.
The new config style is as follows:
```
{
    "minecraft:obsidian": {"resistance": 9, "count": 2},
    "minecraft:end_stone": {"resistance": 5, "count": 0},
}
```